### PR TITLE
feat(cli): add PostHog telemetry tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,6 +2708,7 @@ dependencies = [
  "jiff",
  "libc",
  "open",
+ "parking_lot",
  "pbkdf2",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ getrandom = "0.4"
 libc = "0.2"
 tempfile = "3"
 jiff = "0.2"
+parking_lot = "0.12"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/docs/references/steel-cli.md
+++ b/docs/references/steel-cli.md
@@ -77,6 +77,8 @@ For generated flags and argument schemas, use [../cli-reference.md](../cli-refer
 - Browser session state: `~/.config/steel/browser-session-state.json`
 - Profile metadata: `~/.config/steel/profiles/<name>.json`
 
+On the first run where telemetry is enabled, the CLI prints a one-time notice to stderr describing what is collected and how to opt out. The notice is suppressed in JSON/non-TTY output.
+
 Telemetry can be disabled persistently in `config.json` with:
 
 ```json

--- a/docs/references/steel-cli.md
+++ b/docs/references/steel-cli.md
@@ -73,8 +73,19 @@ For generated flags and argument schemas, use [../cli-reference.md](../cli-refer
 
 - Config directory: `~/.config/steel`
 - Main config: `~/.config/steel/config.json`
+- Telemetry state: `~/.config/steel/telemetry.json`
 - Browser session state: `~/.config/steel/browser-session-state.json`
 - Profile metadata: `~/.config/steel/profiles/<name>.json`
+
+Telemetry can be disabled persistently in `config.json` with:
+
+```json
+{
+  "telemetry": {
+    "disabled": true
+  }
+}
+```
 
 ## Environment Variables (Common)
 
@@ -83,6 +94,8 @@ For generated flags and argument schemas, use [../cli-reference.md](../cli-refer
 - `STEEL_BROWSER_API_URL`: canonical self-hosted local endpoint override.
 - `STEEL_LOCAL_API_URL`: backward-compatible self-hosted alias.
 - `STEEL_CONFIG_DIR`: override config directory root.
+- `STEEL_TELEMETRY_HOST`: override the PostHog ingest host.
+- `STEEL_TELEMETRY_DISABLED`: force telemetry off.
 - `STEEL_PROFILE`: default profile name for browser sessions.
 
 ## Key References

--- a/src/commands/browser/action.rs
+++ b/src/commands/browser/action.rs
@@ -161,6 +161,50 @@ pub enum ActionCommand {
     Close,
 }
 
+impl ActionCommand {
+    pub const fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::Navigate(_) => "navigate",
+            Self::Back => "back",
+            Self::Forward => "forward",
+            Self::Reload => "reload",
+            Self::Click(_) => "click",
+            Self::DblClick(_) => "dblclick",
+            Self::Fill(_) => "fill",
+            Self::Type(_) => "type",
+            Self::Press(_) => "press",
+            Self::Hover(_) => "hover",
+            Self::Focus(_) => "focus",
+            Self::Check(_) => "check",
+            Self::Uncheck(_) => "uncheck",
+            Self::Select(_) => "select",
+            Self::Clear(_) => "clear",
+            Self::SelectAll(_) => "selectall",
+            Self::Scroll(_) => "scroll",
+            Self::ScrollIntoView(_) => "scrollintoview",
+            Self::SetValue(_) => "setvalue",
+            Self::Snapshot(_) => "snapshot",
+            Self::Screenshot(_) => "screenshot",
+            Self::Eval(_) => "eval",
+            Self::Find(_) => "find",
+            Self::Content => "content",
+            Self::Get { .. } => "get",
+            Self::Is { .. } => "is",
+            Self::Wait(_) => "wait",
+            Self::Tab { .. } => "tab",
+            Self::Cookies { .. } => "cookies",
+            Self::Storage { .. } => "storage",
+            Self::Drag(_) => "drag",
+            Self::Upload(_) => "upload",
+            Self::Highlight(_) => "highlight",
+            Self::Set { .. } => "set",
+            Self::BringToFront => "bringtofront",
+            Self::Diff { .. } => "diff",
+            Self::Close => "close",
+        }
+    }
+}
+
 // ── Get subcommands ─────────────────────────────────────────────────
 
 #[derive(Subcommand)]

--- a/src/commands/browser/captcha.rs
+++ b/src/commands/browser/captcha.rs
@@ -16,6 +16,15 @@ pub enum Command {
     Status(StatusArgs),
 }
 
+impl Command {
+    pub const fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::Solve(_) => "solve",
+            Self::Status(_) => "status",
+        }
+    }
+}
+
 #[derive(Parser)]
 pub struct SolveArgs {
     /// Explicit session ID (overrides --session name lookup)

--- a/src/commands/browser/mod.rs
+++ b/src/commands/browser/mod.rs
@@ -46,6 +46,20 @@ pub enum Command {
     Action(action::ActionCommand),
 }
 
+impl Command {
+    pub fn telemetry_name(&self) -> String {
+        match self {
+            Self::Start(_) => "start".to_string(),
+            Self::Stop(_) => "stop".to_string(),
+            Self::Sessions(_) => "sessions".to_string(),
+            Self::Live(_) => "live".to_string(),
+            Self::Captcha { command } => format!("captcha.{}", command.telemetry_name()),
+            Self::Batch(_) => "batch".to_string(),
+            Self::Action(action) => action.telemetry_name().to_string(),
+        }
+    }
+}
+
 pub async fn run(args: BrowserArgs) -> anyhow::Result<()> {
     let session = args.session;
     if let Some(ref name) = session

--- a/src/commands/browser/start.rs
+++ b/src/commands/browser/start.rs
@@ -73,6 +73,8 @@ pub async fn run(args: Args, session: Option<&str>) -> anyhow::Result<()> {
     }
 
     let persist_profile = args.profile.is_some() && args.update_profile;
+    let proxy_enabled = args.proxy.is_some();
+    let namespace_set = args.namespace.is_some();
 
     // If a daemon is already running for this session name, stop it first.
     // `start` always creates a fresh session — use `steel browser sessions`
@@ -121,6 +123,19 @@ pub async fn run(args: Args, session: Option<&str>) -> anyhow::Result<()> {
             stored_browser.as_deref(),
         )?;
     }
+
+    let mut properties = serde_json::Map::new();
+    properties.insert("stealth".into(), json!(args.stealth));
+    properties.insert("proxy_enabled".into(), json!(proxy_enabled));
+    properties.insert("has_profile".into(), json!(args.profile.is_some()));
+    properties.insert("persist_profile".into(), json!(persist_profile));
+    properties.insert("credentials".into(), json!(args.credentials));
+    properties.insert("namespace_set".into(), json!(namespace_set));
+    properties.insert(
+        "session_timeout_set".into(),
+        json!(args.session_timeout.is_some()),
+    );
+    crate::telemetry::track_event("browser_session_started", properties);
 
     display_session_info(&info);
 

--- a/src/commands/browser/stop.rs
+++ b/src/commands/browser/stop.rs
@@ -16,6 +16,7 @@ pub async fn run(args: Args, session: Option<&str>) -> anyhow::Result<()> {
         anyhow::bail!("Cannot combine `--all` with `--session`.");
     }
 
+    let stopped_count;
     if args.all {
         let names = process::list_daemon_names();
         if names.is_empty() {
@@ -30,6 +31,7 @@ pub async fn run(args: Args, session: Option<&str>) -> anyhow::Result<()> {
         for name in &names {
             let _ = process::stop_daemon(name).await;
         }
+        stopped_count = names.len() as u64;
 
         if output::is_json() {
             output::success_data(json!({ "stoppedSessions": names }));
@@ -39,6 +41,7 @@ pub async fn run(args: Args, session: Option<&str>) -> anyhow::Result<()> {
     } else {
         let session_name = session.unwrap_or("default");
         process::stop_daemon(session_name).await?;
+        stopped_count = 1;
 
         if output::is_json() {
             output::success_data(json!({ "stoppedSessions": [session_name] }));
@@ -46,6 +49,11 @@ pub async fn run(args: Args, session: Option<&str>) -> anyhow::Result<()> {
             println!("Stopped session \"{session_name}\".");
         }
     }
+
+    let mut properties = serde_json::Map::new();
+    properties.insert("all".into(), json!(args.all));
+    properties.insert("stopped_count".into(), json!(stopped_count));
+    crate::telemetry::track_event("browser_session_stopped", properties);
 
     Ok(())
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -32,5 +32,9 @@ pub async fn run(_args: Args) -> anyhow::Result<()> {
         println!("browser.apiUrl: {url}");
     }
 
+    if let Some(ref cfg) = config {
+        println!("telemetry.disabled: {}", cfg.telemetry_disabled());
+    }
+
     Ok(())
 }

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -19,6 +19,17 @@ pub enum Command {
     Delete(DeleteArgs),
 }
 
+impl Command {
+    pub const fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::List(_) => "list",
+            Self::Create(_) => "create",
+            Self::Update(_) => "update",
+            Self::Delete(_) => "delete",
+        }
+    }
+}
+
 #[derive(Parser)]
 pub struct ListArgs {
     /// Filter by namespace

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -17,6 +17,16 @@ pub enum Command {
     Stop(StopArgs),
 }
 
+impl Command {
+    pub const fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::Install(_) => "install",
+            Self::Start(_) => "start",
+            Self::Stop(_) => "stop",
+        }
+    }
+}
+
 #[derive(Parser)]
 pub struct InstallArgs {
     /// Git repository URL for local Steel Browser runtime

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -27,6 +27,8 @@ pub async fn run(_args: Args) -> anyhow::Result<()> {
 
     save_api_key(&api_key, &name)?;
 
+    crate::telemetry::track_event("login_completed", serde_json::Map::new());
+
     status!("Authentication successful! Your API key has been saved.");
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -188,6 +188,8 @@ Environment:
   STEEL_BROWSER_API_URL                Steel Browser API endpoint
   STEEL_LOCAL_API_URL                  Local runtime API endpoint
   STEEL_CONFIG_DIR                     Custom config directory
+  STEEL_TELEMETRY_HOST                 PostHog ingest host override
+  STEEL_TELEMETRY_DISABLED             Disable built-in telemetry for this machine/session
   STEEL_FORCE_TTY                      Force text output when piped (disable auto-JSON)
   NO_COLOR                             Disable colored output
 
@@ -312,11 +314,46 @@ pub enum Command {
     Completion(completion::Args),
 }
 
+fn telemetry_command_path(command: &Command) -> Option<String> {
+    match command {
+        Command::Daemon { .. } => None,
+        Command::Scrape(_) => Some("scrape".to_string()),
+        Command::Screenshot(_) => Some("screenshot".to_string()),
+        Command::Pdf(_) => Some("pdf".to_string()),
+        Command::Browser(args) => Some(format!("browser.{}", args.command.telemetry_name())),
+        Command::Init(_) => Some("init".to_string()),
+        Command::Login(_) => Some("login".to_string()),
+        Command::Logout(_) => Some("logout".to_string()),
+        Command::Credentials { command } => {
+            Some(format!("credentials.{}", command.telemetry_name()))
+        }
+        Command::Dev { command } => Some(format!("dev.{}", command.telemetry_name())),
+        Command::Forge(_) => Some("forge".to_string()),
+        Command::Config(_) => Some("config".to_string()),
+        Command::Update(_) => Some("update".to_string()),
+        Command::Cache(_) => Some("cache".to_string()),
+        Command::Profile { command } => Some(format!("profile.{}", command.telemetry_name())),
+        Command::Describe(_) => Some("describe".to_string()),
+        Command::Doctor(_) => Some("doctor".to_string()),
+        Command::Completion(_) => Some("completion".to_string()),
+    }
+}
+
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
+    let telemetry_context =
+        telemetry_command_path(&cli.command).map(|path| crate::telemetry::command_context(&path));
+
     crate::util::output::init(cli.json);
     crate::util::api::init(cli.local, cli.api_url);
+    crate::telemetry::init_from_env();
 
-    match cli.command {
+    if let Some(ref context) = telemetry_context {
+        crate::telemetry::track_command_started(context);
+    }
+
+    let started_at = std::time::Instant::now();
+
+    let result = match cli.command {
         Command::Daemon { session_name } => {
             let params_json = std::env::var("STEEL_DAEMON_PARAMS")
                 .map_err(|_| anyhow::anyhow!("Missing STEEL_DAEMON_PARAMS"))?;
@@ -342,5 +379,214 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Describe(args) => describe::run(args).await,
         Command::Doctor(args) => doctor::run(args).await,
         Command::Completion(args) => completion::run(args).await,
+    };
+
+    if let Some(ref context) = telemetry_context {
+        let duration = started_at.elapsed();
+        match &result {
+            Ok(()) => crate::telemetry::track_command_completed(context, duration),
+            Err(err) => crate::telemetry::track_command_failed(context, duration, err),
+        }
+    }
+
+    crate::telemetry::flush_best_effort().await;
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, OnceLock};
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn capture_events(server: &MockServer) -> Vec<serde_json::Value> {
+        server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|request| serde_json::from_slice(&request.body).unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn successful_command_emits_started_and_completed_events() {
+        let _guard = env_lock().lock().unwrap();
+        crate::telemetry::reset_for_test();
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let server = MockServer::start().await;
+        crate::telemetry::set_test_override(temp.path(), &server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/i/v0/e/"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let result = run(Cli {
+            command: Command::Cache(cache::Args { clean: false }),
+            json: false,
+            no_update_check: true,
+            local: false,
+            api_url: None,
+        })
+        .await;
+
+        assert!(result.is_ok());
+
+        let events = capture_events(&server).await;
+        crate::telemetry::reset_for_test();
+
+        assert_eq!(events.len(), 3);
+        assert!(
+            events
+                .iter()
+                .any(|event| event["event"] == "install_created")
+        );
+        assert!(events.iter().any(|event| {
+            event["event"] == "command_started" && event["properties"]["command_path"] == "cache"
+        }));
+        assert!(events.iter().any(|event| {
+            event["event"] == "command_completed"
+                && event["properties"]["command_path"] == "cache"
+                && event["properties"]["success"] == true
+                && event["properties"]["mode"] == "cloud"
+        }));
+    }
+
+    #[tokio::test]
+    async fn failing_command_emits_started_and_failed_events() {
+        let _guard = env_lock().lock().unwrap();
+        crate::telemetry::reset_for_test();
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let server = MockServer::start().await;
+        crate::telemetry::set_test_override(temp.path(), &server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/i/v0/e/"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let result = run(Cli {
+            command: Command::Browser(browser::BrowserArgs {
+                session: Some("named-session".into()),
+                command: browser::Command::Stop(browser::stop::Args { all: true }),
+            }),
+            json: false,
+            no_update_check: true,
+            local: false,
+            api_url: None,
+        })
+        .await;
+
+        assert!(result.is_err());
+
+        let events = capture_events(&server).await;
+        crate::telemetry::reset_for_test();
+
+        assert_eq!(events.len(), 3);
+        assert!(
+            events
+                .iter()
+                .any(|event| event["event"] == "install_created")
+        );
+        assert!(events.iter().any(|event| {
+            event["event"] == "command_started"
+                && event["properties"]["command_path"] == "browser.stop"
+        }));
+        assert!(events.iter().any(|event| {
+            event["event"] == "command_failed"
+                && event["properties"]["command_path"] == "browser.stop"
+                && event["properties"]["success"] == false
+                && event["properties"]["error_class"] == "internal_error"
+        }));
+    }
+
+    #[tokio::test]
+    async fn telemetry_delivery_failure_does_not_fail_command() {
+        let _guard = env_lock().lock().unwrap();
+        crate::telemetry::reset_for_test();
+
+        let temp = tempfile::TempDir::new().unwrap();
+        crate::telemetry::set_test_override(temp.path(), "http://127.0.0.1:1");
+
+        let result = run(Cli {
+            command: Command::Cache(cache::Args { clean: false }),
+            json: false,
+            no_update_check: true,
+            local: false,
+            api_url: None,
+        })
+        .await;
+
+        crate::telemetry::reset_for_test();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn install_created_emits_only_once_per_config_dir() {
+        let _guard = env_lock().lock().unwrap();
+        crate::telemetry::reset_for_test();
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let server = MockServer::start().await;
+        crate::telemetry::set_test_override(temp.path(), &server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/i/v0/e/"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let first = run(Cli {
+            command: Command::Cache(cache::Args { clean: false }),
+            json: false,
+            no_update_check: true,
+            local: false,
+            api_url: None,
+        })
+        .await;
+        assert!(first.is_ok());
+
+        crate::telemetry::reset_for_test();
+        crate::telemetry::set_test_override(temp.path(), &server.uri());
+
+        let second = run(Cli {
+            command: Command::Cache(cache::Args { clean: false }),
+            json: false,
+            no_update_check: true,
+            local: false,
+            api_url: None,
+        })
+        .await;
+        assert!(second.is_ok());
+
+        let events = capture_events(&server).await;
+        crate::telemetry::reset_for_test();
+
+        let install_created_count = events
+            .iter()
+            .filter(|event| event["event"] == "install_created")
+            .count();
+        let command_completed_count = events
+            .iter()
+            .filter(|event| event["event"] == "command_completed")
+            .count();
+
+        assert_eq!(install_created_count, 1);
+        assert_eq!(command_completed_count, 2);
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -409,13 +409,14 @@ mod tests {
     }
 
     async fn capture_events(server: &MockServer) -> Vec<serde_json::Value> {
-        server
-            .received_requests()
-            .await
-            .unwrap_or_default()
-            .into_iter()
-            .map(|request| serde_json::from_slice(&request.body).unwrap())
-            .collect()
+        let mut out = Vec::new();
+        for request in server.received_requests().await.unwrap_or_default() {
+            let payload: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            if let Some(batch) = payload.get("batch").and_then(|v| v.as_array()) {
+                out.extend(batch.iter().cloned());
+            }
+        }
+        out
     }
 
     #[tokio::test]
@@ -428,7 +429,7 @@ mod tests {
         crate::telemetry::set_test_override(temp.path(), &server.uri());
 
         Mock::given(method("POST"))
-            .and(path("/i/v0/e/"))
+            .and(path("/batch/"))
             .respond_with(ResponseTemplate::new(200))
             .mount(&server)
             .await;
@@ -474,7 +475,7 @@ mod tests {
         crate::telemetry::set_test_override(temp.path(), &server.uri());
 
         Mock::given(method("POST"))
-            .and(path("/i/v0/e/"))
+            .and(path("/batch/"))
             .respond_with(ResponseTemplate::new(200))
             .mount(&server)
             .await;
@@ -546,7 +547,7 @@ mod tests {
         crate::telemetry::set_test_override(temp.path(), &server.uri());
 
         Mock::given(method("POST"))
-            .and(path("/i/v0/e/"))
+            .and(path("/batch/"))
             .respond_with(ResponseTemplate::new(200))
             .mount(&server)
             .await;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -396,8 +396,9 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::OnceLock;
 
+    use tokio::sync::Mutex;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -421,7 +422,7 @@ mod tests {
 
     #[tokio::test]
     async fn successful_command_emits_started_and_completed_events() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock().lock().await;
         crate::telemetry::reset_for_test();
 
         let temp = tempfile::TempDir::new().unwrap();
@@ -467,7 +468,7 @@ mod tests {
 
     #[tokio::test]
     async fn failing_command_emits_started_and_failed_events() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock().lock().await;
         crate::telemetry::reset_for_test();
 
         let temp = tempfile::TempDir::new().unwrap();
@@ -517,7 +518,7 @@ mod tests {
 
     #[tokio::test]
     async fn telemetry_delivery_failure_does_not_fail_command() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock().lock().await;
         crate::telemetry::reset_for_test();
 
         let temp = tempfile::TempDir::new().unwrap();
@@ -539,7 +540,7 @@ mod tests {
 
     #[tokio::test]
     async fn install_created_emits_only_once_per_config_dir() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock().lock().await;
         crate::telemetry::reset_for_test();
 
         let temp = tempfile::TempDir::new().unwrap();

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -20,6 +20,17 @@ pub enum Command {
     Delete(DeleteArgs),
 }
 
+impl Command {
+    pub const fn telemetry_name(&self) -> &'static str {
+        match self {
+            Self::List(_) => "list",
+            Self::Import(_) => "import",
+            Self::Sync(_) => "sync",
+            Self::Delete(_) => "delete",
+        }
+    }
+}
+
 #[derive(Parser)]
 pub struct ListArgs {}
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -110,6 +110,8 @@ pub struct Config {
     pub instance: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub browser: Option<BrowserConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub telemetry: Option<TelemetryConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
@@ -119,6 +121,13 @@ pub struct BrowserConfig {
     pub api_url: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TelemetryConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+}
+
 impl Config {
     /// Extract the local API URL from config.browser.apiUrl
     pub fn local_api_url(&self) -> Option<&str> {
@@ -126,6 +135,13 @@ impl Config {
             .as_ref()
             .and_then(|b| b.api_url.as_deref())
             .filter(|s| !s.trim().is_empty())
+    }
+
+    pub fn telemetry_disabled(&self) -> bool {
+        self.telemetry
+            .as_ref()
+            .and_then(|t| t.disabled)
+            .unwrap_or(false)
     }
 }
 
@@ -181,6 +197,9 @@ mod tests {
             browser: Some(BrowserConfig {
                 api_url: Some("http://localhost:4000/v1".into()),
             }),
+            telemetry: Some(TelemetryConfig {
+                disabled: Some(true),
+            }),
         };
 
         write_config_to(&path, &config).unwrap();
@@ -190,6 +209,7 @@ mod tests {
         assert_eq!(loaded.name.as_deref(), Some("CLI"));
         assert_eq!(loaded.instance.as_deref(), Some("cloud"));
         assert_eq!(loaded.local_api_url(), Some("http://localhost:4000/v1"));
+        assert!(loaded.telemetry_disabled());
     }
 
     #[test]
@@ -209,13 +229,14 @@ mod tests {
         let path = dir.path().join("config.json");
         std::fs::write(
             &path,
-            r#"{"apiKey":"k","name":"n","instance":"cloud","browser":{"apiUrl":"http://x"}}"#,
+            r#"{"apiKey":"k","name":"n","instance":"cloud","browser":{"apiUrl":"http://x"},"telemetry":{"disabled":true}}"#,
         )
         .unwrap();
 
         let config = read_config_from(&path).unwrap();
         assert_eq!(config.api_key.as_deref(), Some("k"));
         assert_eq!(config.local_api_url(), Some("http://x"));
+        assert!(config.telemetry_disabled());
     }
 
     #[test]
@@ -240,6 +261,12 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(config.local_api_url(), None);
+    }
+
+    #[test]
+    fn telemetry_disabled_defaults_false() {
+        let config = Config::default();
+        assert!(!config.telemetry_disabled());
     }
 
     // --- ApiMode tests ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod api;
 pub mod browser;
 pub mod commands;
 pub mod config;
+pub mod telemetry;
 pub mod util;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,17 +1,20 @@
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use tokio::sync::Notify;
 
 use crate::config;
 use crate::config::settings::ApiMode;
 
 const DEFAULT_POSTHOG_HOST: &str = "https://us.i.posthog.com";
 const PROJECT_TOKEN: &str = "phc_yhxgGFVDmaCpccF38yspn4pAkVLFnHsGaWmYUyijuuRS";
-const CAPTURE_PATH: &str = "/i/v0/e/";
-const FLUSH_TIMEOUT: Duration = Duration::from_millis(150);
+const BATCH_PATH: &str = "/batch/";
+const FLUSH_INTERVAL: Duration = Duration::from_secs(10);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 static GLOBAL: OnceLock<Mutex<GlobalTelemetry>> = OnceLock::new();
@@ -26,7 +29,20 @@ fn global() -> &'static Mutex<GlobalTelemetry> {
 #[derive(Default)]
 struct GlobalTelemetry {
     client: Option<Arc<TelemetryClient>>,
-    pending: Vec<tokio::task::JoinHandle<()>>,
+    queue: Vec<QueuedEvent>,
+    flusher: Option<FlusherHandle>,
+}
+
+struct FlusherHandle {
+    shutdown: Arc<Notify>,
+    join: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone)]
+struct QueuedEvent {
+    event: String,
+    properties: Map<String, Value>,
+    timestamp_ms: u64,
 }
 
 #[cfg(test)]
@@ -39,7 +55,7 @@ struct TestTelemetryOverride {
 #[derive(Clone)]
 struct TelemetryClient {
     http: reqwest::Client,
-    capture_url: String,
+    batch_url: String,
     api_key: String,
     distinct_id: String,
 }
@@ -109,7 +125,7 @@ impl TelemetryClient {
         Some(TelemetryBootstrap {
             client: Arc::new(Self {
                 http,
-                capture_url: format!("{host}{CAPTURE_PATH}"),
+                batch_url: format!("{host}{BATCH_PATH}"),
                 api_key: PROJECT_TOKEN.to_string(),
                 distinct_id: identity.distinct_id,
             }),
@@ -125,7 +141,6 @@ pub fn init_from_env() {
         let override_state = TEST_OVERRIDE
             .get_or_init(|| Mutex::new(None))
             .lock()
-            .unwrap()
             .clone();
         override_state
             .and_then(|state| {
@@ -150,19 +165,50 @@ pub fn init_from_env() {
         )
     };
 
-    let mut state = global().lock().unwrap();
-    state.client = bootstrap
-        .as_ref()
-        .map(|bootstrap| Arc::clone(&bootstrap.client));
-    state.pending.clear();
+    let previous_flusher = {
+        let mut state = global().lock();
+        state.client = bootstrap
+            .as_ref()
+            .map(|bootstrap| Arc::clone(&bootstrap.client));
+        state.queue.clear();
+        state.flusher.take()
+    };
+
+    if let Some(previous) = previous_flusher {
+        previous.join.abort();
+    }
+
+    if let Some(bootstrap) = bootstrap.as_ref()
+        && let Ok(handle) = tokio::runtime::Handle::try_current()
+    {
+        let shutdown = Arc::new(Notify::new());
+        let client = Arc::clone(&bootstrap.client);
+        let shutdown_clone = Arc::clone(&shutdown);
+        let join = handle.spawn(run_flusher(client, shutdown_clone));
+        global().lock().flusher = Some(FlusherHandle { shutdown, join });
+    }
+
     let install_created = bootstrap
         .as_ref()
         .is_some_and(|bootstrap| bootstrap.install_created);
-    drop(state);
 
     if install_created {
+        emit_first_run_notice();
         track_event("install_created", Map::new());
     }
+}
+
+fn emit_first_run_notice() {
+    if crate::util::output::is_json() {
+        return;
+    }
+    eprintln!();
+    eprintln!("Steel CLI collects anonymous usage data to help improve the product.");
+    eprintln!("No URLs, selectors, credentials, or command arguments are sent.");
+    eprintln!(
+        "Opt out: set STEEL_TELEMETRY_DISABLED=1, or add `\"telemetry\": {{\"disabled\": true}}` to ~/.config/steel/config.json"
+    );
+    eprintln!();
 }
 
 pub fn command_context(command_path: &str) -> CommandContext {
@@ -203,69 +249,93 @@ pub fn track_event(event: &str, mut properties: Map<String, Value>) {
 }
 
 pub async fn flush_best_effort() {
-    let handles = {
-        let mut state = global().lock().unwrap();
-        state.pending.drain(..).collect::<Vec<_>>()
+    let flusher = {
+        let mut state = global().lock();
+        state.flusher.take()
     };
 
-    if handles.is_empty() {
+    let Some(flusher) = flusher else {
         return;
-    }
+    };
 
-    let _ = tokio::time::timeout(FLUSH_TIMEOUT, async move {
-        for handle in handles {
-            let _ = handle.await;
-        }
-    })
-    .await;
+    flusher.shutdown.notify_one();
+    let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, flusher.join).await;
 }
 
 fn track(event: &str, properties: Map<String, Value>) {
-    let client = {
-        let state = global().lock().unwrap();
-        state.client.clone()
-    };
-
-    let Some(client) = client else {
+    let mut state = global().lock();
+    if state.client.is_none() {
         return;
-    };
-
-    let Ok(handle) = tokio::runtime::Handle::try_current() else {
-        return;
-    };
-
-    let event = event.to_string();
-    let join = handle.spawn(async move {
-        let payload =
-            build_capture_payload(&client.api_key, &client.distinct_id, &event, properties);
-        let _ = client
-            .http
-            .post(&client.capture_url)
-            .json(&payload)
-            .send()
-            .await;
+    }
+    state.queue.push(QueuedEvent {
+        event: event.to_string(),
+        properties,
+        timestamp_ms: now_unix_ms(),
     });
-
-    let mut state = global().lock().unwrap();
-    state.pending.push(join);
 }
 
-fn build_capture_payload(
-    api_key: &str,
-    distinct_id: &str,
-    event: &str,
-    mut properties: Map<String, Value>,
-) -> Value {
-    properties.insert("$process_person_profile".into(), json!(false));
-    properties.insert("$lib".into(), json!("steel-cli"));
-    properties.insert("$lib_version".into(), json!(env!("CARGO_PKG_VERSION")));
+async fn run_flusher(client: Arc<TelemetryClient>, shutdown: Arc<Notify>) {
+    let mut interval = tokio::time::interval(FLUSH_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    interval.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                flush_once(&client).await;
+            }
+            () = shutdown.notified() => {
+                flush_once(&client).await;
+                break;
+            }
+        }
+    }
+}
+
+async fn flush_once(client: &TelemetryClient) {
+    let events = {
+        let mut state = global().lock();
+        std::mem::take(&mut state.queue)
+    };
+    if events.is_empty() {
+        return;
+    }
+    let payload = build_batch_payload(&client.api_key, &client.distinct_id, &events);
+    let _ = client
+        .http
+        .post(&client.batch_url)
+        .json(&payload)
+        .send()
+        .await;
+}
+
+fn build_batch_payload(api_key: &str, distinct_id: &str, events: &[QueuedEvent]) -> Value {
+    let batch: Vec<Value> = events
+        .iter()
+        .map(|e| {
+            let mut properties = e.properties.clone();
+            properties.insert("$process_person_profile".into(), json!(false));
+            properties.insert("$lib".into(), json!("steel-cli"));
+            properties.insert("$lib_version".into(), json!(env!("CARGO_PKG_VERSION")));
+            json!({
+                "event": e.event,
+                "distinct_id": distinct_id,
+                "properties": properties,
+                "timestamp": format_timestamp(e.timestamp_ms),
+            })
+        })
+        .collect();
 
     json!({
         "api_key": api_key,
-        "event": event,
-        "distinct_id": distinct_id,
-        "properties": properties,
+        "batch": batch,
     })
+}
+
+fn format_timestamp(ms: u64) -> String {
+    jiff::Timestamp::from_millisecond(ms as i64)
+        .map(|ts| ts.to_string())
+        .unwrap_or_else(|_| ms.to_string())
 }
 
 fn default_properties() -> Map<String, Value> {
@@ -399,14 +469,19 @@ fn now_unix_ms() -> u64 {
 
 #[cfg(test)]
 pub fn reset_for_test() {
-    let mut state = global().lock().unwrap();
-    for handle in state.pending.drain(..) {
-        handle.abort();
+    let flusher = {
+        let mut state = global().lock();
+        state.queue.clear();
+        state.client = None;
+        state.flusher.take()
+    };
+
+    if let Some(flusher) = flusher {
+        flusher.join.abort();
     }
-    state.client = None;
 
     if let Some(lock) = TEST_OVERRIDE.get() {
-        *lock.lock().unwrap() = None;
+        *lock.lock() = None;
     }
 }
 
@@ -421,7 +496,7 @@ pub fn set_test_override(config_dir: &Path, host: &str) {
     };
 
     let lock = TEST_OVERRIDE.get_or_init(|| Mutex::new(None));
-    *lock.lock().unwrap() = Some(override_state);
+    *lock.lock() = Some(override_state);
 }
 
 #[cfg(test)]
@@ -461,7 +536,7 @@ mod tests {
 
         let client = TelemetryClient::from_parts(dir.path(), &env, None).unwrap();
 
-        assert_eq!(client.client.capture_url, "http://127.0.0.1:9999/i/v0/e/");
+        assert_eq!(client.client.batch_url, "http://127.0.0.1:9999/batch/");
     }
 
     #[test]
@@ -519,16 +594,25 @@ mod tests {
     }
 
     #[test]
-    fn capture_payload_includes_distinct_id_and_properties() {
+    fn batch_payload_includes_events_with_distinct_id_and_timestamp() {
         let mut properties = Map::new();
         properties.insert("command_path".into(), json!("config"));
 
-        let payload = build_capture_payload("phc_test", "anon-123", "command_started", properties);
+        let events = vec![QueuedEvent {
+            event: "command_started".into(),
+            properties,
+            timestamp_ms: 1_700_000_000_000,
+        }];
+
+        let payload = build_batch_payload("phc_test", "anon-123", &events);
 
         assert_eq!(payload["api_key"], "phc_test");
-        assert_eq!(payload["event"], "command_started");
-        assert_eq!(payload["distinct_id"], "anon-123");
-        assert_eq!(payload["properties"]["command_path"], "config");
-        assert_eq!(payload["properties"]["$process_person_profile"], false);
+        let batch = payload["batch"].as_array().unwrap();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0]["event"], "command_started");
+        assert_eq!(batch[0]["distinct_id"], "anon-123");
+        assert_eq!(batch[0]["properties"]["command_path"], "config");
+        assert_eq!(batch[0]["properties"]["$process_person_profile"], false);
+        assert_eq!(batch[0]["timestamp"], "2023-11-14T22:13:20Z");
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,534 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+use crate::config;
+use crate::config::settings::ApiMode;
+
+const DEFAULT_POSTHOG_HOST: &str = "https://us.i.posthog.com";
+const PROJECT_TOKEN: &str = "phc_yhxgGFVDmaCpccF38yspn4pAkVLFnHsGaWmYUyijuuRS";
+const CAPTURE_PATH: &str = "/i/v0/e/";
+const FLUSH_TIMEOUT: Duration = Duration::from_millis(150);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+static GLOBAL: OnceLock<Mutex<GlobalTelemetry>> = OnceLock::new();
+
+#[cfg(test)]
+static TEST_OVERRIDE: OnceLock<Mutex<Option<TestTelemetryOverride>>> = OnceLock::new();
+
+fn global() -> &'static Mutex<GlobalTelemetry> {
+    GLOBAL.get_or_init(|| Mutex::new(GlobalTelemetry::default()))
+}
+
+#[derive(Default)]
+struct GlobalTelemetry {
+    client: Option<Arc<TelemetryClient>>,
+    pending: Vec<tokio::task::JoinHandle<()>>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct TestTelemetryOverride {
+    config_dir: PathBuf,
+    env: TelemetryEnv,
+}
+
+#[derive(Clone)]
+struct TelemetryClient {
+    http: reqwest::Client,
+    capture_url: String,
+    api_key: String,
+    distinct_id: String,
+}
+
+struct TelemetryBootstrap {
+    client: Arc<TelemetryClient>,
+    install_created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandContext {
+    command_path: String,
+}
+
+#[derive(Debug, Default, Clone)]
+struct TelemetryEnv {
+    host: Option<String>,
+    disabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TelemetryState {
+    anonymous_install_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_seen_unix_ms: Option<u64>,
+}
+
+impl TelemetryEnv {
+    fn from_env() -> Self {
+        Self {
+            host: std::env::var("STEEL_TELEMETRY_HOST").ok(),
+            disabled: std::env::var("STEEL_TELEMETRY_DISABLED")
+                .ok()
+                .is_some_and(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True")),
+        }
+    }
+}
+
+impl TelemetryClient {
+    fn from_parts(
+        config_dir: &Path,
+        env: &TelemetryEnv,
+        config: Option<&crate::config::settings::Config>,
+    ) -> Option<TelemetryBootstrap> {
+        if telemetry_disabled(env, config) {
+            return None;
+        }
+
+        let host = env
+            .host
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(DEFAULT_POSTHOG_HOST)
+            .trim_end_matches('/')
+            .to_string();
+
+        let http = reqwest::Client::builder()
+            .user_agent(format!("steel-cli/{}", env!("CARGO_PKG_VERSION")))
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .ok()?;
+
+        let identity = load_or_create_anonymous_install_id(config_dir);
+
+        Some(TelemetryBootstrap {
+            client: Arc::new(Self {
+                http,
+                capture_url: format!("{host}{CAPTURE_PATH}"),
+                api_key: PROJECT_TOKEN.to_string(),
+                distinct_id: identity.distinct_id,
+            }),
+            install_created: identity.is_new,
+        })
+    }
+}
+
+pub fn init_from_env() {
+    #[cfg(test)]
+    let bootstrap = {
+        let config = crate::config::settings::read_config().ok();
+        let override_state = TEST_OVERRIDE
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .unwrap()
+            .clone();
+        override_state
+            .and_then(|state| {
+                TelemetryClient::from_parts(&state.config_dir, &state.env, config.as_ref())
+            })
+            .or_else(|| {
+                TelemetryClient::from_parts(
+                    &config::config_dir(),
+                    &TelemetryEnv::from_env(),
+                    config.as_ref(),
+                )
+            })
+    };
+
+    #[cfg(not(test))]
+    let bootstrap = {
+        let config = crate::config::settings::read_config().ok();
+        TelemetryClient::from_parts(
+            &config::config_dir(),
+            &TelemetryEnv::from_env(),
+            config.as_ref(),
+        )
+    };
+
+    let mut state = global().lock().unwrap();
+    state.client = bootstrap
+        .as_ref()
+        .map(|bootstrap| Arc::clone(&bootstrap.client));
+    state.pending.clear();
+    let install_created = bootstrap
+        .as_ref()
+        .is_some_and(|bootstrap| bootstrap.install_created);
+    drop(state);
+
+    if install_created {
+        track_event("install_created", Map::new());
+    }
+}
+
+pub fn command_context(command_path: &str) -> CommandContext {
+    CommandContext {
+        command_path: command_path.to_string(),
+    }
+}
+
+pub fn track_command_started(context: &CommandContext) {
+    let mut properties = default_properties();
+    properties.insert("command_path".into(), json!(context.command_path));
+    track("command_started", properties);
+}
+
+pub fn track_command_completed(context: &CommandContext, duration: Duration) {
+    let mut properties = default_properties();
+    properties.insert("command_path".into(), json!(context.command_path));
+    properties.insert("success".into(), json!(true));
+    properties.insert("duration_ms".into(), json!(duration.as_millis() as u64));
+    track("command_completed", properties);
+}
+
+pub fn track_command_failed(context: &CommandContext, duration: Duration, err: &anyhow::Error) {
+    let mut properties = default_properties();
+    properties.insert("command_path".into(), json!(context.command_path));
+    properties.insert("success".into(), json!(false));
+    properties.insert("duration_ms".into(), json!(duration.as_millis() as u64));
+    properties.insert("error_class".into(), json!(error_class(err)));
+    track("command_failed", properties);
+}
+
+pub fn track_event(event: &str, mut properties: Map<String, Value>) {
+    let defaults = default_properties();
+    for (key, value) in defaults {
+        properties.entry(key).or_insert(value);
+    }
+    track(event, properties);
+}
+
+pub async fn flush_best_effort() {
+    let handles = {
+        let mut state = global().lock().unwrap();
+        state.pending.drain(..).collect::<Vec<_>>()
+    };
+
+    if handles.is_empty() {
+        return;
+    }
+
+    let _ = tokio::time::timeout(FLUSH_TIMEOUT, async move {
+        for handle in handles {
+            let _ = handle.await;
+        }
+    })
+    .await;
+}
+
+fn track(event: &str, properties: Map<String, Value>) {
+    let client = {
+        let state = global().lock().unwrap();
+        state.client.clone()
+    };
+
+    let Some(client) = client else {
+        return;
+    };
+
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+
+    let event = event.to_string();
+    let join = handle.spawn(async move {
+        let payload =
+            build_capture_payload(&client.api_key, &client.distinct_id, &event, properties);
+        let _ = client
+            .http
+            .post(&client.capture_url)
+            .json(&payload)
+            .send()
+            .await;
+    });
+
+    let mut state = global().lock().unwrap();
+    state.pending.push(join);
+}
+
+fn build_capture_payload(
+    api_key: &str,
+    distinct_id: &str,
+    event: &str,
+    mut properties: Map<String, Value>,
+) -> Value {
+    properties.insert("$process_person_profile".into(), json!(false));
+    properties.insert("$lib".into(), json!("steel-cli"));
+    properties.insert("$lib_version".into(), json!(env!("CARGO_PKG_VERSION")));
+
+    json!({
+        "api_key": api_key,
+        "event": event,
+        "distinct_id": distinct_id,
+        "properties": properties,
+    })
+}
+
+fn default_properties() -> Map<String, Value> {
+    let mut properties = Map::new();
+    properties.insert("cli_version".into(), json!(env!("CARGO_PKG_VERSION")));
+    properties.insert("os".into(), json!(std::env::consts::OS));
+    properties.insert("arch".into(), json!(std::env::consts::ARCH));
+    properties.insert("json".into(), json!(crate::util::output::is_json()));
+    properties.insert("mode".into(), json!(telemetry_mode()));
+    properties
+}
+
+fn telemetry_disabled(
+    env: &TelemetryEnv,
+    config: Option<&crate::config::settings::Config>,
+) -> bool {
+    env.disabled || config.is_some_and(crate::config::settings::Config::telemetry_disabled)
+}
+
+fn telemetry_mode() -> &'static str {
+    let (mode, base_url) = crate::util::api::resolve();
+    match mode {
+        ApiMode::Cloud if base_url == config::DEFAULT_API_URL => "cloud",
+        ApiMode::Local if base_url == config::DEFAULT_LOCAL_API_URL => "local",
+        _ => "self_hosted",
+    }
+}
+
+fn error_class(err: &anyhow::Error) -> &'static str {
+    if let Some(api_err) = err.downcast_ref::<crate::api::client::ApiError>() {
+        return match api_err {
+            crate::api::client::ApiError::MissingAuth => "auth_required",
+            crate::api::client::ApiError::Unreachable { .. } => "network_unreachable",
+            crate::api::client::ApiError::RequestFailed { status, .. } => match *status {
+                401 => "api_unauthorized",
+                403 => "api_forbidden",
+                404 | 410 => "api_not_found",
+                429 => "api_rate_limited",
+                s if s >= 500 => "api_server_error",
+                _ => "api_request_failed",
+            },
+            crate::api::client::ApiError::Other(_) => "network_error",
+        };
+    }
+
+    if err.chain().any(|source| source.is::<std::io::Error>()) {
+        return "io_error";
+    }
+
+    "internal_error"
+}
+
+struct TelemetryIdentity {
+    distinct_id: String,
+    is_new: bool,
+}
+
+fn load_or_create_anonymous_install_id(config_dir: &Path) -> TelemetryIdentity {
+    let path = telemetry_state_path(config_dir);
+
+    if let Ok(contents) = std::fs::read_to_string(&path)
+        && let Ok(state) = serde_json::from_str::<TelemetryState>(&contents)
+        && !state.anonymous_install_id.trim().is_empty()
+    {
+        return TelemetryIdentity {
+            distinct_id: state.anonymous_install_id,
+            is_new: false,
+        };
+    }
+
+    let anonymous_install_id = generate_uuid_like_id();
+    let state = TelemetryState {
+        anonymous_install_id: anonymous_install_id.clone(),
+        first_seen_unix_ms: Some(now_unix_ms()),
+    };
+    let _ = write_telemetry_state(&path, &state);
+
+    TelemetryIdentity {
+        distinct_id: anonymous_install_id,
+        is_new: true,
+    }
+}
+
+fn telemetry_state_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("telemetry.json")
+}
+
+fn write_telemetry_state(path: &Path, state: &TelemetryState) -> anyhow::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let payload = serde_json::to_vec_pretty(state)?;
+    std::fs::write(&tmp, payload)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+fn generate_uuid_like_id() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::fill(&mut bytes).expect("failed to generate telemetry install id");
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    )
+}
+
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+pub fn reset_for_test() {
+    let mut state = global().lock().unwrap();
+    for handle in state.pending.drain(..) {
+        handle.abort();
+    }
+    state.client = None;
+
+    if let Some(lock) = TEST_OVERRIDE.get() {
+        *lock.lock().unwrap() = None;
+    }
+}
+
+#[cfg(test)]
+pub fn set_test_override(config_dir: &Path, host: &str) {
+    let override_state = TestTelemetryOverride {
+        config_dir: config_dir.to_path_buf(),
+        env: TelemetryEnv {
+            host: Some(host.to_string()),
+            disabled: false,
+        },
+    };
+
+    let lock = TEST_OVERRIDE.get_or_init(|| Mutex::new(None));
+    *lock.lock().unwrap() = Some(override_state);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn telemetry_enabled_by_default() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let env = TelemetryEnv::default();
+
+        let client = TelemetryClient::from_parts(dir.path(), &env, None);
+
+        assert!(client.is_some());
+    }
+
+    #[test]
+    fn telemetry_disabled_env_flag_turns_client_off() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let env = TelemetryEnv {
+            disabled: true,
+            ..Default::default()
+        };
+
+        let client = TelemetryClient::from_parts(dir.path(), &env, None);
+
+        assert!(client.is_none());
+    }
+
+    #[test]
+    fn telemetry_uses_host_override() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let env = TelemetryEnv {
+            host: Some("http://127.0.0.1:9999/".into()),
+            ..Default::default()
+        };
+
+        let client = TelemetryClient::from_parts(dir.path(), &env, None).unwrap();
+
+        assert_eq!(client.client.capture_url, "http://127.0.0.1:9999/i/v0/e/");
+    }
+
+    #[test]
+    fn telemetry_disabled_in_config_turns_client_off() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let env = TelemetryEnv::default();
+        let config = crate::config::settings::Config {
+            telemetry: Some(crate::config::settings::TelemetryConfig {
+                disabled: Some(true),
+            }),
+            ..Default::default()
+        };
+
+        let client = TelemetryClient::from_parts(dir.path(), &env, Some(&config));
+
+        assert!(client.is_none());
+    }
+
+    #[test]
+    fn anonymous_install_id_persists() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let first = load_or_create_anonymous_install_id(dir.path());
+        let second = load_or_create_anonymous_install_id(dir.path());
+
+        assert_eq!(first.distinct_id, second.distinct_id);
+        assert!(first.is_new);
+        assert!(!second.is_new);
+    }
+
+    #[test]
+    fn malformed_telemetry_state_regenerates_id() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = telemetry_state_path(dir.path());
+        std::fs::write(&path, "{not-json").unwrap();
+
+        let id = load_or_create_anonymous_install_id(dir.path());
+
+        assert!(!id.distinct_id.is_empty());
+        assert!(id.is_new);
+        let contents = std::fs::read_to_string(path).unwrap();
+        assert!(contents.contains("anonymousInstallId"));
+    }
+
+    #[test]
+    fn unreadable_telemetry_state_falls_back_to_ephemeral_id() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = telemetry_state_path(dir.path());
+        std::fs::create_dir_all(&path).unwrap();
+
+        let id = load_or_create_anonymous_install_id(dir.path());
+
+        assert!(!id.distinct_id.is_empty());
+        assert!(id.is_new);
+    }
+
+    #[test]
+    fn capture_payload_includes_distinct_id_and_properties() {
+        let mut properties = Map::new();
+        properties.insert("command_path".into(), json!("config"));
+
+        let payload = build_capture_payload("phc_test", "anon-123", "command_started", properties);
+
+        assert_eq!(payload["api_key"], "phc_test");
+        assert_eq!(payload["event"], "command_started");
+        assert_eq!(payload["distinct_id"], "anon-123");
+        assert_eq!(payload["properties"]["command_path"], "config");
+        assert_eq!(payload["properties"]["$process_person_profile"], false);
+    }
+}


### PR DESCRIPTION
## Summary
- add built-in PostHog telemetry for CLI command lifecycle and browser/login milestones
- add anonymous install identity persistence plus a one-shot install_created event
- support persistent telemetry opt-out in config.json and env-based host/disable overrides

## Testing
- cargo fmt --all
- cargo test --lib